### PR TITLE
Include `nextPageToken` in `User.history` Return Result

### DIFF
--- a/lib/gmail/history.ex
+++ b/lib/gmail/history.ex
@@ -28,6 +28,8 @@ defmodule Gmail.History do
         :not_found
       {:ok, %{"error" => %{"code" => 400, "errors" => errors}}} ->
         {:error, errors}
+      {:ok, %{"history" => history, "nextPageToken" => next_page_token}} ->
+        {:ok, Utils.atomise_keys(history), next_page_token}
       {:ok, %{"history" => history}} ->
         {:ok, Utils.atomise_keys(history)}
     end


### PR DESCRIPTION
If `nextPageToken` is present in the `users.history.list` response, `User.history` returns:
```
{:ok, history, next_page_token}
```
If not, `User.history` returns:
```
{:ok, history}
```

This behaviour is similar to that of `Gmail.User.threads`.

See https://developers.google.com/gmail/api/reference/rest/v1/users.history/list#response-body