### PR TITLE
Fix: Handle History List Response With No History

### DIFF
--- a/lib/gmail/history.ex
+++ b/lib/gmail/history.ex
@@ -32,6 +32,8 @@ defmodule Gmail.History do
         {:ok, Utils.atomise_keys(history), next_page_token}
       {:ok, %{"history" => history}} ->
         {:ok, Utils.atomise_keys(history)}
+      {:ok, %{"historyId" => _historyId}} ->
+        {:ok, []}
     end
   end
 


### PR DESCRIPTION
It seems that the `users.history.list` method can sometimes return just `historyId`, for example:
```
{
  "historyId": "3135842"
}
```